### PR TITLE
Add Parameter Suggestion Endpoint with LibertAI Integration

### DIFF
--- a/conf/conf_client.yml
+++ b/conf/conf_client.yml
@@ -107,7 +107,7 @@ gateway:
   gateway_api_host: localhost
   gateway_api_port: '15888'
 
-certs_path: ./certs
+certs_path: certs
 
 # Whether to enable aggregated order and trade data collection
 anonymized_metrics_mode:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,23 +1,26 @@
 [build-system]
-requires = ["setuptools>=42", "wheel"]
-build-backend = "setuptools.build_meta"
+requires = ["hatchling"]
+build-backend = "hatchling.build"
 
-[tool.black]
-line-length = 130
-target-version = ["py38"]
+[project]
+name = "robotter-backend-api"
+version = "0.1.0"
+authors = [
+  { name="Mike Henry" },
+]
+description = "Robotter Backend API"
+readme = "README.md"
+requires-python = ">=3.10"
 
-[tool.isort]
-line_length = 130
-profile = "black"
-multi_line_output = 3
-include_trailing_comma = true
-use_parentheses = true
-ensure_newline_before_comments = true
-combine_as_imports = true
-
-[tool.pre-commit]
-repos = [
-    { repo = "https://github.com/pre-commit/pre-commit-hooks", rev = "v3.4.0", hooks = [{ id = "check-yaml" }, { id = "end-of-file-fixer" }] },
-    { repo = "https://github.com/psf/black", rev = "21.6b0", hooks = [{ id = "black" }] },
-    { repo = "https://github.com/pre-commit/mirrors-isort", rev = "v5.9.3", hooks = [{ id = "isort" }] }
+[tool.pytest.ini_options]
+pythonpath = [
+  "."
+]
+asyncio_mode = "strict"
+testpaths = [
+    "tests",
+]
+filterwarnings = [
+    "ignore::DeprecationWarning",
+    "ignore::UserWarning",
 ]

--- a/routers/__init__.py
+++ b/routers/__init__.py
@@ -1,0 +1,3 @@
+"""
+Router package initialization.
+"""

--- a/routers/backtest.py
+++ b/routers/backtest.py
@@ -8,6 +8,7 @@ from hummingbot.strategy_v2.backtesting.controllers_backtesting.market_making_ba
 
 from config import CONTROLLERS_MODULE, CONTROLLERS_PATH
 from routers.backtest_models import BacktestResponse, BacktestResults, BacktestingConfig, ExecutorInfo, ProcessedData
+from routers.strategies_models import StrategyError
 
 router = APIRouter(tags=["Market Backtesting"])
 candles_factory = CandlesFactory()
@@ -19,37 +20,84 @@ BACKTESTING_ENGINES = {
     "market_making": market_making_backtesting
 }
 
+class BacktestError(StrategyError):
+    """Base class for backtesting-related errors"""
+
+class BacktestConfigError(BacktestError):
+    """Raised when there's an error in the backtesting configuration"""
+
+class BacktestEngineError(BacktestError):
+    """Raised when there's an error during backtesting execution"""
+
 @router.post("/backtest", response_model=BacktestResponse)
 async def run_backtesting(backtesting_config: BacktestingConfig) -> BacktestResponse:
     try:
-        if isinstance(backtesting_config.config, str):
-            controller_config = BacktestingEngineBase.get_controller_config_instance_from_yml(
-                config_path=backtesting_config.config,
-                controllers_conf_dir_path=CONTROLLERS_PATH,
-                controllers_module=CONTROLLERS_MODULE
-            )
-        else:
-            controller_config = BacktestingEngineBase.get_controller_config_instance_from_dict(
-                config_data=backtesting_config.config,
-                controllers_module=CONTROLLERS_MODULE
-            )
+        # Load and validate controller config
+        try:
+            if isinstance(backtesting_config.config, str):
+                controller_config = BacktestingEngineBase.get_controller_config_instance_from_yml(
+                    config_path=backtesting_config.config,
+                    controllers_conf_dir_path=CONTROLLERS_PATH,
+                    controllers_module=CONTROLLERS_MODULE
+                )
+            else:
+                controller_config = BacktestingEngineBase.get_controller_config_instance_from_dict(
+                    config_data=backtesting_config.config,
+                    controllers_module=CONTROLLERS_MODULE
+                )
+        except Exception as e:
+            raise BacktestConfigError(f"Invalid controller configuration: {str(e)}")
+
+        # Get and validate backtesting engine
         backtesting_engine = BACKTESTING_ENGINES.get(controller_config.controller_type)
         if not backtesting_engine:
-            raise ValueError(f"Backtesting engine for controller type {controller_config.controller_type} not found.")
-        backtesting_results = await backtesting_engine.run_backtesting(
-            controller_config=controller_config, trade_cost=backtesting_config.trade_cost,
-            start=int(backtesting_config.start_time), end=int(backtesting_config.end_time),
-            backtesting_resolution=backtesting_config.backtesting_resolution)
-        
-        processed_data = backtesting_results["processed_data"]["features"].fillna(0).to_dict()
-        executors_info = [ExecutorInfo(**e.to_dict()) for e in backtesting_results["executors"]]
-        results = backtesting_results["results"]
-        results["sharpe_ratio"] = results["sharpe_ratio"] if results["sharpe_ratio"] is not None else 0
-        
-        return BacktestResponse(
-            executors=executors_info,
-            processed_data=ProcessedData(features=processed_data),
-            results=BacktestResults(**results)
-        )
-    except Exception as e:
+            raise BacktestConfigError(
+                f"Backtesting engine for controller type {controller_config.controller_type} not found. "
+                f"Available types: {list(BACKTESTING_ENGINES.keys())}"
+            )
+
+        # Validate time range
+        if backtesting_config.end_time <= backtesting_config.start_time:
+            raise BacktestConfigError(
+                f"Invalid time range: end_time ({backtesting_config.end_time}) must be greater than "
+                f"start_time ({backtesting_config.start_time})"
+            )
+
+        try:
+            # Run backtesting
+            backtesting_results = await backtesting_engine.run_backtesting(
+                controller_config=controller_config,
+                trade_cost=backtesting_config.trade_cost,
+                start=int(backtesting_config.start_time),
+                end=int(backtesting_config.end_time),
+                backtesting_resolution=backtesting_config.backtesting_resolution
+            )
+        except Exception as e:
+            raise BacktestEngineError(f"Error during backtesting execution: {str(e)}")
+
+        try:
+            # Process results
+            processed_data = backtesting_results["processed_data"]["features"].fillna(0).to_dict()
+            executors_info = [ExecutorInfo(**e.to_dict()) for e in backtesting_results["executors"]]
+            results = backtesting_results["results"]
+            results["sharpe_ratio"] = results["sharpe_ratio"] if results["sharpe_ratio"] is not None else 0
+            
+            return BacktestResponse(
+                executors=executors_info,
+                processed_data=ProcessedData(features=processed_data),
+                results=BacktestResults(**results)
+            )
+        except Exception as e:
+            raise BacktestError(f"Error processing backtesting results: {str(e)}")
+
+    except BacktestConfigError as e:
         raise HTTPException(status_code=400, detail=str(e))
+    except BacktestEngineError as e:
+        raise HTTPException(status_code=500, detail=str(e))
+    except BacktestError as e:
+        raise HTTPException(status_code=500, detail=str(e))
+    except Exception as e:
+        raise HTTPException(
+            status_code=500,
+            detail=f"Unexpected error during backtesting: {str(e)}"
+        )

--- a/routers/bots.py
+++ b/routers/bots.py
@@ -5,103 +5,191 @@ from services.docker_service import DockerManager
 from fastapi_walletauth import JWTWalletAuthDep
 from utils.models import HummingbotInstanceConfig, StartStrategyRequest, InstanceResponse
 from hummingbot.core.gateway.gateway_http_client import GatewayHttpClient
+from routers.strategies_models import (
+    StrategyError,
+    StrategyRegistry,
+    StrategyNotFoundError,
+    StrategyValidationError
+)
 
 router = APIRouter(tags=["Bot Management"])
 accounts_service = AccountsService()
 docker_manager = DockerManager()
 gateway_client = GatewayHttpClient.get_instance()
 
+class BotError(StrategyError):
+    """Base class for bot-related errors"""
+
+class BotNotFoundError(BotError):
+    """Raised when a bot cannot be found"""
+
+class BotPermissionError(BotError):
+    """Raised when there's a permission error with bot operations"""
+
+class BotConfigError(BotError):
+    """Raised when there's an error in bot configuration"""
 
 class CreateBotRequest(BaseModel):
     strategy_name: str
     strategy_parameters: dict
     market: str
 
-
 @router.post("/bots", response_model=InstanceResponse)
 async def create_bot(request: CreateBotRequest, wallet_auth: JWTWalletAuthDep):
-    bot_account = f"robotter_{wallet_auth.address}_{request.market}_{request.strategy_name}"
-    accounts_service.add_account(bot_account)
-    wallet_address = await accounts_service.generate_bot_wallet(bot_account)
+    try:
+        # Validate strategy exists and parameters
+        try:
+            strategy = StrategyRegistry.get_strategy(request.strategy_name)
+        except StrategyNotFoundError as e:
+            raise BotConfigError(f"Invalid strategy: {str(e)}")
 
-    # Save strategy configuration and market
-    bot_config = BotConfig(
-        strategy_name=request.strategy_name,
-        parameters=request.strategy_parameters,
-        market=request.market,
-        wallet_address=wallet_auth.address,
-    )
-    accounts_service.save_bot_config(bot_account, bot_config)
-    # Create Hummingbot instance
-    instance_config = HummingbotInstanceConfig(
-        instance_name=bot_account, credentials_profile=bot_account, image="mlguys/hummingbot:mango", market=request.market
-    )
-    result = docker_manager.create_hummingbot_instance(instance_config)
+        try:
+            validate_strategy_parameters(strategy, request.strategy_parameters)
+        except StrategyValidationError as e:
+            raise BotConfigError(f"Invalid strategy parameters: {str(e)}")
 
-    if not result["success"]:
-        raise HTTPException(status_code=500, detail=result["message"])
+        # Create bot account
+        bot_account = f"robotter_{wallet_auth.address}_{request.market}_{request.strategy_name}"
+        try:
+            accounts_service.add_account(bot_account)
+            wallet_address = await accounts_service.generate_bot_wallet(bot_account)
+        except Exception as e:
+            raise BotError(f"Error creating bot account: {str(e)}")
 
-    return InstanceResponse(instance_id=bot_account, wallet_address=wallet_address, market=request.market)
+        # Save strategy configuration and market
+        try:
+            bot_config = BotConfig(
+                strategy_name=request.strategy_name,
+                parameters=request.strategy_parameters,
+                market=request.market,
+                wallet_address=wallet_auth.address,
+            )
+            accounts_service.save_bot_config(bot_account, bot_config)
+        except Exception as e:
+            raise BotConfigError(f"Error saving bot configuration: {str(e)}")
 
+        # Create Hummingbot instance
+        try:
+            instance_config = HummingbotInstanceConfig(
+                instance_name=bot_account,
+                credentials_profile=bot_account,
+                image="mlguys/hummingbot:mango",
+                market=request.market
+            )
+            result = docker_manager.create_hummingbot_instance(instance_config)
+
+            if not result["success"]:
+                raise BotError(result["message"])
+        except Exception as e:
+            raise BotError(f"Error creating Hummingbot instance: {str(e)}")
+
+        return InstanceResponse(
+            instance_id=bot_account,
+            wallet_address=wallet_address,
+            market=request.market
+        )
+
+    except BotConfigError as e:
+        raise HTTPException(status_code=400, detail=str(e))
+    except BotPermissionError as e:
+        raise HTTPException(status_code=403, detail=str(e))
+    except BotError as e:
+        raise HTTPException(status_code=500, detail=str(e))
+    except Exception as e:
+        raise HTTPException(
+            status_code=500,
+            detail=f"Unexpected error creating bot: {str(e)}"
+        )
 
 @router.get("/bots/{bot_id}/wallet")
 async def get_bot_wallet(bot_id: str, wallet_auth: JWTWalletAuthDep):
     try:
         # Check if the bot belongs to the authenticated user
         if not bot_id.endswith(wallet_auth.address):
-            raise HTTPException(status_code=403, detail="You don't have permission to access this bot")
+            raise BotPermissionError("You don't have permission to access this bot")
 
-        wallet_address = accounts_service.get_bot_wallet_address(bot_id)
-        return {"wallet_address": wallet_address}
-    except Exception as e:
+        try:
+            wallet_address = accounts_service.get_bot_wallet_address(bot_id)
+            return {"wallet_address": wallet_address}
+        except Exception as e:
+            raise BotNotFoundError(f"Bot wallet not found: {str(e)}")
+
+    except BotPermissionError as e:
+        raise HTTPException(status_code=403, detail=str(e))
+    except BotNotFoundError as e:
         raise HTTPException(status_code=404, detail=str(e))
-
+    except Exception as e:
+        raise HTTPException(
+            status_code=500,
+            detail=f"Unexpected error getting bot wallet: {str(e)}"
+        )
 
 @router.post("/bots/{bot_id}/start")
 async def start_bot(bot_id: str, start_request: StartStrategyRequest, wallet_auth: JWTWalletAuthDep):
-    # Check if the bot belongs to the authenticated user
-    bot_config = accounts_service.get_bot_config(bot_id)
-    if not bot_config or bot_config.wallet_address != wallet_auth.address:
-        raise HTTPException(status_code=403, detail="You don't have permission to start this bot")
+    try:
+        # Check if the bot belongs to the authenticated user
+        bot_config = accounts_service.get_bot_config(bot_id)
+        if not bot_config or bot_config.wallet_address != wallet_auth.address:
+            raise BotPermissionError("You don't have permission to start this bot")
 
-    # Check if Mango account exists and is associated with the bot's wallet
-    bot_wallet = accounts_service.get_bot_wallet_address(bot_id)
+        # Check if Mango account exists and is associated with the bot's wallet
+        try:
+            bot_wallet = accounts_service.get_bot_wallet_address(bot_id)
+            mango_account_info = await gateway_client.get_mango_account(
+                "solana", "mainnet", "mango_perpetual_solana_mainnet-beta", bot_wallet
+            )
 
-    # We should pass the wallet address
-    mango_account_info = await gateway_client.get_mango_account(
-        "solana", "mainnet", "mango_perpetual_solana_mainnet-beta", bot_wallet
-    )
+            if not mango_account_info or mango_account_info.get("owner") != bot_wallet:
+                raise BotConfigError("Invalid Mango account or not associated with the bot's wallet")
+        except Exception as e:
+            raise BotConfigError(f"Error validating Mango account: {str(e)}")
 
-    if not mango_account_info or mango_account_info.get("owner") != bot_wallet:
-        raise HTTPException(status_code=400, detail="Invalid Mango account or not associated with the bot's wallet")
+        # Start the bot
+        try:
+            strategy_config = accounts_service.get_strategy_config(bot_id)
+            start_config = {**strategy_config, **start_request.parameters}
 
-    # Start the bot
-    strategy_config = accounts_service.get_strategy_config(bot_id)
-    start_config = {**strategy_config, **start_request.parameters}
+            response = docker_manager.start_bot(bot_id, start_config)
+            if not response["success"]:
+                raise BotError("Failed to start the bot")
 
-    response = docker_manager.start_bot(bot_id, start_config)
-    if not response["success"]:
-        raise HTTPException(status_code=500, detail="Failed to start the bot")
+            return {"status": "success", "message": "Bot started successfully"}
+        except Exception as e:
+            raise BotError(f"Error starting bot: {str(e)}")
 
-    return {"status": "success", "message": "Bot started successfully"}
+    except BotPermissionError as e:
+        raise HTTPException(status_code=403, detail=str(e))
+    except BotConfigError as e:
+        raise HTTPException(status_code=400, detail=str(e))
+    except BotError as e:
+        raise HTTPException(status_code=500, detail=str(e))
+    except Exception as e:
+        raise HTTPException(
+            status_code=500,
+            detail=f"Unexpected error starting bot: {str(e)}"
+        )
 
-
-@router.post("/bots/{bot_id}/stop")
-async def stop_bot(bot_id: str, wallet_auth: JWTWalletAuthDep):
-    # Check if the bot belongs to the authenticated user
-    if not bot_id.endswith(wallet_auth.address):
-        raise HTTPException(status_code=403, detail="You don't have permission to stop this bot")
-
-    # Stop the bot and cancel all orders
-    response = docker_manager.stop_bot(bot_id)
-    if not response["success"]:
-        raise HTTPException(status_code=500, detail="Failed to stop the bot")
-
-    # Cancel all orders through the gateway
-    bot_wallet = accounts_service.get_bot_wallet_address(bot_id)
-    cancel_orders_response = await gateway_client.clob_perp_get_orders("solana", "mainnet", "mango_perpetual_solana_mainnet-beta")
-
-    if not cancel_orders_response["success"]:
-        raise HTTPException(status_code=500, detail="Failed to cancel all orders")
-
-    return {"status": "success", "message": "Bot stopped and all orders cancelled successfully"} 
+def validate_strategy_parameters(strategy, parameters: dict) -> None:
+    """Validate strategy parameters against their constraints"""
+    for param_name, value in parameters.items():
+        if param_name not in strategy.parameters:
+            raise StrategyValidationError(f"Unknown parameter: {param_name}")
+            
+        param = strategy.parameters[param_name]
+        constraints = param.constraints
+        
+        if constraints:
+            if constraints.min_value is not None and value < constraints.min_value:
+                raise StrategyValidationError(
+                    f"Parameter {param_name} value {value} is below minimum {constraints.min_value}"
+                )
+                
+            if constraints.max_value is not None and value > constraints.max_value:
+                raise StrategyValidationError(
+                    f"Parameter {param_name} value {value} is above maximum {constraints.max_value}"
+                )
+                
+            if constraints.valid_values is not None and value not in constraints.valid_values:
+                raise StrategyValidationError(
+                    f"Parameter {param_name} value {value} is not one of the valid values: {constraints.valid_values}"
+                ) 

--- a/routers/strategies.py
+++ b/routers/strategies.py
@@ -1,4 +1,4 @@
-from typing import Dict
+from typing import Dict, Any
 from fastapi import APIRouter, HTTPException
 from fastapi import FastAPI
 from contextlib import asynccontextmanager
@@ -8,7 +8,10 @@ from routers.strategies_models import (
     ParameterSuggestionRequest,
     ParameterSuggestionResponse,
     StrategyConfig,
-    discover_strategies
+    StrategyRegistry,
+    StrategyNotFoundError,
+    StrategyValidationError,
+    StrategyError
 )
 
 # Create a libert_ai_service instance
@@ -20,7 +23,7 @@ async def lifespan(app: FastAPI):
     try:
         # Load strategies using auto-discovery
         print("Initializing LibertAI contexts...")
-        strategies = discover_strategies()
+        strategies = StrategyRegistry.get_all_strategies()
         await libert_ai_service.initialize_contexts(strategies)
         print(f"Successfully initialized contexts for {len(strategies)} strategies")
     except Exception as e:
@@ -39,10 +42,14 @@ router = APIRouter()
 async def get_strategies() -> Dict[str, StrategyConfig]:
     """Get all available strategies and their configurations."""
     try:
-        # Use auto-discovery to get strategies
-        return discover_strategies()
+        return StrategyRegistry.get_all_strategies()
+    except StrategyError as e:
+        raise HTTPException(status_code=400, detail=str(e))
     except Exception as e:
-        raise HTTPException(status_code=500, detail=str(e))
+        raise HTTPException(
+            status_code=500,
+            detail=f"Internal server error while fetching strategies: {str(e)}"
+        )
 
 @router.post("/strategies/suggest-parameters")
 async def suggest_parameters(request: ParameterSuggestionRequest) -> ParameterSuggestionResponse:
@@ -54,13 +61,17 @@ async def suggest_parameters(request: ParameterSuggestionRequest) -> ParameterSu
     Otherwise, will suggest values for all missing required parameters.
     """
     try:
-        # Get strategy configuration using auto-discovery
-        strategies = discover_strategies()
+        # Get strategy using the registry
+        try:
+            strategy = StrategyRegistry.get_strategy(request.strategy_id)
+        except StrategyNotFoundError as e:
+            raise HTTPException(status_code=404, detail=str(e))
         
-        if request.strategy_id not in strategies:
-            raise HTTPException(status_code=404, detail=f"Strategy '{request.strategy_id}' not found")
-        
-        strategy = strategies[request.strategy_id]
+        # Validate parameters against constraints
+        try:
+            validate_parameters(strategy, request.parameters)
+        except StrategyValidationError as e:
+            raise HTTPException(status_code=400, detail=str(e))
         
         # Ensure context is initialized for this strategy
         if request.strategy_id not in libert_ai_service.strategy_slot_map:
@@ -90,9 +101,40 @@ async def suggest_parameters(request: ParameterSuggestionRequest) -> ParameterSu
             )
             
         except Exception as e:
-            raise HTTPException(status_code=500, detail=str(e))
+            raise HTTPException(
+                status_code=500,
+                detail=f"Error getting parameter suggestions: {str(e)}"
+            )
             
     except HTTPException:
         raise
     except Exception as e:
-        raise HTTPException(status_code=500, detail=str(e))
+        raise HTTPException(
+            status_code=500,
+            detail=f"Unexpected error processing parameter suggestions: {str(e)}"
+        )
+
+def validate_parameters(strategy: StrategyConfig, parameters: Dict[str, Any]) -> None:
+    """Validate parameters against their constraints"""
+    for param_name, value in parameters.items():
+        if param_name not in strategy.parameters:
+            raise StrategyValidationError(f"Unknown parameter: {param_name}")
+            
+        param = strategy.parameters[param_name]
+        constraints = param.constraints
+        
+        if constraints:
+            if constraints.min_value is not None and value < constraints.min_value:
+                raise StrategyValidationError(
+                    f"Parameter {param_name} value {value} is below minimum {constraints.min_value}"
+                )
+                
+            if constraints.max_value is not None and value > constraints.max_value:
+                raise StrategyValidationError(
+                    f"Parameter {param_name} value {value} is above maximum {constraints.max_value}"
+                )
+                
+            if constraints.valid_values is not None and value not in constraints.valid_values:
+                raise StrategyValidationError(
+                    f"Parameter {param_name} value {value} is not one of the valid values: {constraints.valid_values}"
+                )

--- a/routers/strategies.py
+++ b/routers/strategies.py
@@ -1,8 +1,5 @@
-import json
-import os
-from typing import Dict, List
+from typing import Dict
 from fastapi import APIRouter, HTTPException
-from pydantic import BaseModel
 from fastapi import FastAPI
 from contextlib import asynccontextmanager
 
@@ -11,8 +8,7 @@ from routers.strategies_models import (
     ParameterSuggestionRequest,
     ParameterSuggestionResponse,
     StrategyConfig,
-    discover_strategies,
-    get_strategy_mapping
+    discover_strategies
 )
 
 # Create a libert_ai_service instance

--- a/routers/strategies.py
+++ b/routers/strategies.py
@@ -1,11 +1,91 @@
-from typing import Dict
+import json
+import os
+from typing import Dict, List
+from fastapi import APIRouter, HTTPException
+from pydantic import BaseModel
+from fastapi import FastAPI
+from contextlib import asynccontextmanager
 
-from fastapi import APIRouter
-from .strategies_models import StrategyParameter, get_all_strategy_maps
+from services.libert_ai_service import LibertAIService
+from routers.strategies_models import (
+    ParameterSuggestionRequest,
+    ParameterSuggestionResponse,
+    StrategyConfig,
+    discover_strategies,
+    get_strategy_mapping
+)
 
-router = APIRouter(tags=["Strategies"])
+# Create a libert_ai_service instance
+libert_ai_service = LibertAIService()
 
+@asynccontextmanager
+async def lifespan(app: FastAPI):
+    # Initialize contexts on startup
+    try:
+        # Load strategies using auto-discovery
+        strategies = discover_strategies()
+        await libert_ai_service.initialize_contexts(strategies)
+    except Exception as e:
+        print(f"Error initializing LibertAI contexts: {str(e)}")
+    yield
 
-@router.get("/strategies", response_model=Dict[str, Dict[str, StrategyParameter]])
-async def get_strategies():
-    return get_all_strategy_maps()
+# Create the FastAPI app with the lifespan handler
+app = FastAPI(lifespan=lifespan)
+router = APIRouter()
+
+@router.get("/strategies")
+async def get_strategies() -> Dict[str, StrategyConfig]:
+    """Get all available strategies and their configurations."""
+    try:
+        # Use auto-discovery to get strategies
+        return discover_strategies()
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=str(e))
+
+@router.post("/strategies/suggest-parameters")
+async def suggest_parameters(request: ParameterSuggestionRequest) -> ParameterSuggestionResponse:
+    """
+    Suggest parameter values for a strategy based on the provided parameters.
+    Uses LibertAI to analyze and suggest optimal values for missing or requested parameters.
+    
+    If requested_parameters is provided, will only suggest values for those specific parameters.
+    Otherwise, will suggest values for all missing required parameters.
+    """
+    try:
+        # Get strategy configuration using auto-discovery
+        strategies = discover_strategies()
+        
+        if request.strategy_id not in strategies:
+            raise HTTPException(status_code=404, detail=f"Strategy '{request.strategy_id}' not found")
+        
+        strategy = strategies[request.strategy_id]
+        
+        try:
+            # Get suggestions from LibertAI
+            suggestions = await libert_ai_service.get_parameter_suggestions(
+                strategy_id=request.strategy_id,
+                strategy_config=strategy.parameters,
+                provided_params=request.parameters,
+                requested_params=request.requested_parameters
+            )
+            
+            # Extract summary from the last suggestion if it exists
+            summary = "No suggestions available."
+            if suggestions:
+                # Remove the summary suggestion if it exists
+                if suggestions[-1].parameter_name.lower() == "summary":
+                    summary = suggestions[-1].reasoning
+                    suggestions = suggestions[:-1]
+            
+            return ParameterSuggestionResponse(
+                suggestions=suggestions,
+                summary=summary
+            )
+            
+        except Exception as e:
+            raise HTTPException(status_code=500, detail=str(e))
+            
+    except HTTPException:
+        raise
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=str(e))

--- a/services/__init__.py
+++ b/services/__init__.py
@@ -1,0 +1,3 @@
+"""
+Services package initialization.
+"""

--- a/services/libert_ai_service.py
+++ b/services/libert_ai_service.py
@@ -1,0 +1,422 @@
+import os
+import json
+import logging
+import aiohttp
+import inspect
+import importlib
+from typing import Dict, Any, List, Optional
+from routers.strategies_models import (
+    ParameterSuggestion,
+    StrategyConfig,
+    StrategyMapping,
+    discover_strategies
+)
+
+logger = logging.getLogger(__name__)
+
+class LibertAIService:
+    def __init__(self):
+        # Hermes 2 pro
+        self.api_url = "https://curated.aleph.cloud/vm/84df52ac4466d121ef3bb409bb14f315de7be4ce600e8948d71df6485aa5bcc3/completion"
+        
+        self.strategy_slot_map: Dict[str, int] = {}  # Maps strategy IDs to their slot IDs
+        self.next_slot_id = 0
+        
+    async def initialize_contexts(self, strategies: Dict[str, StrategyConfig]):
+        """Initialize context slots for system prompt and each strategy."""
+        try:
+            logger.info("Starting context initialization...")
+            
+            # Initialize system prompt in slot -1
+            logger.info("Initializing system context...")
+            await self._initialize_system_context()
+            
+            # Initialize each strategy's context
+            for strategy_id, strategy_config in strategies.items():
+                logger.info(f"Initializing context for strategy: {strategy_id}")
+                slot_id = self.next_slot_id
+                self.strategy_slot_map[strategy_id] = slot_id
+                self.next_slot_id += 1
+                
+                # Load strategy implementation code
+                strategy_code = await self._load_strategy_code(strategy_config.mapping)
+                logger.info(f"Loaded strategy code for {strategy_id}, code length: {len(strategy_code)}")
+                
+                await self._initialize_strategy_context(
+                    strategy_mapping=strategy_config.mapping,
+                    strategy_config=strategy_config.parameters,
+                    strategy_code=strategy_code,
+                    slot_id=slot_id
+                )
+                
+            logger.info(f"Context initialization complete. Strategy slot map: {self.strategy_slot_map}")
+            
+        except Exception as e:
+            logger.error(f"Error initializing contexts: {str(e)}")
+            raise
+    
+    async def _load_strategy_code(self, mapping: StrategyMapping) -> str:
+        """Load the strategy implementation code using the strategy mapping."""
+        try:
+            # Import the module using the mapping's module path
+            module = importlib.import_module(mapping.module_path)
+            
+            # Get all classes in the module
+            strategy_classes = inspect.getmembers(
+                module,
+                lambda member: (
+                    inspect.isclass(member) 
+                    and member.__module__ == module.__name__
+                    and not member.__name__.endswith('Config')
+                )
+            )
+            
+            if not strategy_classes:
+                raise ValueError(f"No strategy class found in {mapping.module_path}")
+            
+            # Get the source code of the strategy class
+            strategy_class = strategy_classes[0][1]  # Take the first class
+            source_code = inspect.getsource(strategy_class)
+            
+            return source_code
+            
+        except Exception as e:
+            logger.error(f"Error loading strategy code for {mapping.id}: {str(e)}")
+            return f"# Strategy implementation code not found for {mapping.id}"
+    
+    async def _initialize_system_context(self):
+        """Initialize the system prompt in slot -1."""
+        system_prompt = """<|im_start|>system
+You are an expert trading strategy advisor. Your task is to analyze trading strategies and suggest optimal parameter values.
+
+For each parameter suggestion, you must:
+1. Suggest an appropriate value based on the strategy type and configuration
+2. Provide a clear explanation of why this value would be appropriate
+3. Consider potential risks and market conditions
+4. Take into account the strategy's implementation code and logic
+
+Format each suggestion exactly as follows:
+PARAMETER: [parameter_name]
+VALUE: [suggested_value]
+REASONING: [detailed explanation]
+<|im_end|>"""
+
+        try:
+            async with aiohttp.ClientSession() as session:
+                await session.post(
+                    self.api_url,
+                    headers={"Content-Type": "application/json"},
+                    json={
+                        "prompt": system_prompt,
+                        "temperature": 0.9,
+                        "top_p": 1,
+                        "top_k": 40,
+                        "n": 1,
+                        "n_predict": 100,
+                        "stop": ["<|im_end|>"]
+                    }
+                )
+        except Exception as e:
+            print(f"ERROR: Error initializing system context: {str(e)}")
+            raise
+    
+    async def _initialize_strategy_context(
+        self,
+        strategy_mapping: StrategyMapping,
+        strategy_config: Dict[str, Any],
+        strategy_code: str,
+        slot_id: int
+    ):
+        """Initialize context for a specific strategy."""
+        # Convert strategy parameters to a serializable format
+        serializable_config = {
+            name: {
+                "name": param.name,
+                "group": param.group,
+                "type": param.type,
+                "prompt": param.prompt,
+                "default": str(param.default) if param.default is not None else None,
+                "required": param.required,
+                "min_value": str(param.min_value) if param.min_value is not None else None,
+                "max_value": str(param.max_value) if param.max_value is not None else None,
+                "is_advanced": param.is_advanced,
+                "display_type": param.display_type
+            }
+            for name, param in strategy_config.items()
+        }
+
+        strategy_context = f"""<|im_start|>user
+Trading Strategy: {strategy_mapping.display_name}
+Type: {strategy_mapping.strategy_type.value}
+Description: {strategy_mapping.description}
+
+Strategy Configuration Schema:
+{json.dumps(serializable_config, indent=2)}
+
+Strategy Implementation:
+```python
+{strategy_code}
+```
+
+This strategy's configuration defines the parameters and their constraints, while the implementation shows how these parameters are used in the trading logic. Use both to make informed suggestions about parameter values.
+<|im_end|>"""
+
+        try:
+            async with aiohttp.ClientSession() as session:
+                await session.post(
+                    self.api_url,
+                    headers={"Content-Type": "application/json"},
+                    json={
+                        "prompt": strategy_context,
+                        "temperature": 0.9,
+                        "top_p": 1,
+                        "top_k": 40,
+                        "n": 1,
+                        "n_predict": 100,
+                        "stop": ["<|im_end|>"],
+                        "slot_id": slot_id,
+                        "parent_slot_id": -1,
+                    }
+                )
+        except Exception as e:
+            print(f"ERROR: Error initializing strategy context for {strategy_mapping.id}: {str(e)}")
+            raise
+        
+    async def get_parameter_suggestions(
+        self,
+        strategy_id: str,
+        strategy_config: Dict[str, Any],
+        provided_params: Dict[str, Any],
+        requested_params: Optional[List[str]] = None
+    ) -> List[ParameterSuggestion]:
+        """Get parameter suggestions from LibertAI.
+        
+        Args:
+            strategy_id: ID of the strategy
+            strategy_config: Full strategy configuration
+            provided_params: Parameters already provided by the user
+            requested_params: Optional list of specific parameters to get suggestions for
+        """
+        print("\n=== Getting Parameter Suggestions ===")
+        print(f"Strategy ID: {strategy_id}")
+        print(f"Provided parameters: {json.dumps(provided_params, indent=2)}")
+        print(f"Requested parameters: {requested_params}")
+        
+        # Get strategy configuration
+        strategies = discover_strategies()
+        strategy = strategies.get(strategy_id)
+        if not strategy:
+            print(f"ERROR: No strategy found with ID {strategy_id}")
+            return []
+        
+        # Identify missing required parameters and optional parameters
+        missing_required = []
+        optional_params = []
+        
+        # If specific parameters are requested, only consider those
+        params_to_check = requested_params if requested_params else strategy_config.keys()
+        
+        for param_name in params_to_check:
+            if param_name not in provided_params:
+                param_config = strategy_config.get(param_name)
+                if param_config:
+                    if param_config.required:
+                        missing_required.append(param_name)
+                    else:
+                        optional_params.append(param_name)
+        
+        print(f"Missing required parameters: {missing_required}")
+        print(f"Optional parameters: {optional_params}")
+        
+        # Get the strategy's slot ID
+        slot_id = self.strategy_slot_map.get(strategy_id)
+        if slot_id is None:
+            print(f"ERROR: No cached context found for strategy {strategy_id}")
+            return []
+        
+        # Convert parameters to a serializable format
+        serializable_params = {
+            name: str(value) if hasattr(value, "__str__") else value
+            for name, value in provided_params.items()
+        }
+        
+        # Update the prompt to be more explicit about the format and requested parameters
+        optional_params_text = f"Optional Parameters That Could Be Set:\n{', '.join(optional_params) if optional_params else 'None'}" if not requested_params else ""
+
+        request_prompt = f"""<|im_start|>user
+Strategy: {strategy.mapping.display_name}
+Type: {strategy.mapping.strategy_type.value}
+
+Currently Provided Parameters:
+{json.dumps(serializable_params, indent=2)}
+
+{"Parameters to Suggest:" if requested_params else "Missing Required Parameters:"}
+{', '.join(requested_params) if requested_params else ', '.join(missing_required) if missing_required else 'None'}
+
+{optional_params_text}
+
+Please suggest optimal values for {"the requested" if requested_params else "the missing"} parameters using exactly this format for each parameter:
+
+PARAMETER: [parameter_name]
+VALUE: [suggested_value]
+REASONING: [detailed explanation of why this value is appropriate]
+
+End with a summary:
+SUMMARY: [overall explanation of the suggested configuration]
+
+Do not include code blocks or other formats. Use only the PARAMETER/VALUE/REASONING structure.
+<|im_end|>"""
+
+        try:
+            async with aiohttp.ClientSession() as session:
+                print(f"\nSending request to LibertAI API...")
+                print(f"Request prompt:\n{request_prompt}")
+                
+                request_payload = {
+                    "slot_id": self.next_slot_id,
+                    "parent_slot_id": slot_id,
+                    "prompt": request_prompt,
+                    "temperature": 0.9,
+                    "top_p": 1,
+                    "top_k": 40,
+                    "n": 1,
+                    "n_predict": 1500,
+                    "stop": ["<|im_end|>"]
+                }
+                
+                async with session.post(
+                    self.api_url,
+                    headers={"Content-Type": "application/json"},
+                    json=request_payload
+                ) as response:
+                    if response.status != 200:
+                        print(f"ERROR: API returned status {response.status}")
+                        response_text = await response.text()
+                        print(f"Response body: {response_text}")
+                        return []
+                    
+                    result = await response.json()
+                    print(f"\nReceived response from API: {json.dumps(result, indent=2)}")
+                    return self._parse_ai_response(
+                        {"choices": [{"message": {"content": result["content"]}}]},
+                        strategy_config=strategy_config,
+                        provided_params=provided_params
+                    )
+                    
+        except Exception as e:
+            print(f"ERROR: Exception during API call: {str(e)}")
+            return []
+    
+    def _parse_ai_response(self, ai_response: Dict[str, Any], strategy_config: Dict[str, Any], provided_params: Dict[str, Any]) -> List[ParameterSuggestion]:
+        print("\n=== Parsing AI Response ===")
+        try:
+            content = ai_response["choices"][0]["message"]["content"]
+            print(f"Response content preview: {content[:200]}...")
+            
+            suggestions = []
+            seen_params = set()
+            summary = None
+            
+            # Create a map of default values and provided values for comparison
+            default_values = {
+                name: str(param.default) if param.default is not None else None
+                for name, param in strategy_config.items()
+            }
+            
+            provided_values = {
+                name: str(value) if hasattr(value, "__str__") else str(value)
+                for name, value in provided_params.items()
+            }
+            
+            if "PARAMETER:" in content:
+                print("Found structured format with PARAMETER/VALUE/REASONING")
+                parameter_sections = content.split("PARAMETER:")
+                
+                for section in parameter_sections[1:]:
+                    lines = section.strip().split("\n")
+                    param_name = lines[0].strip()
+                    
+                    # Initialize collectors for multi-line values
+                    value_lines = []
+                    reasoning_lines = []
+                    collecting_value = False
+                    collecting_reasoning = False
+                    
+                    # Process remaining lines
+                    for line in lines[1:]:
+                        line = line.strip()
+                        
+                        if line.startswith("VALUE:"):
+                            collecting_value = True
+                            collecting_reasoning = False
+                            value_lines.append(line.replace("VALUE:", "").strip())
+                        elif line.startswith("REASONING:"):
+                            collecting_value = False
+                            collecting_reasoning = True
+                            reasoning_lines.append(line.replace("REASONING:", "").strip())
+                        elif line.startswith("SUMMARY:"):
+                            collecting_value = False
+                            collecting_reasoning = False
+                            summary = line.replace("SUMMARY:", "").strip()
+                        else:
+                            # Continue collecting multi-line values
+                            if collecting_value and line:
+                                value_lines.append(line)
+                            elif collecting_reasoning and line:
+                                reasoning_lines.append(line)
+                    
+                    # Process collected values
+                    if param_name and value_lines and param_name not in seen_params:
+                        seen_params.add(param_name)
+                        
+                        # Join multi-line values and try to parse as JSON if it looks like a JSON structure
+                        value = "\n".join(value_lines)
+                        if value.strip().startswith("{") and value.strip().endswith("}"):
+                            try:
+                                parsed_value = json.loads(value)
+                                value = json.dumps(parsed_value)
+                            except json.JSONDecodeError:
+                                pass
+                        
+                        # Compare with default and provided values
+                        differs_from_default = (
+                            param_name in default_values and 
+                            default_values[param_name] is not None and 
+                            value != default_values[param_name]
+                        )
+                        differs_from_provided = (
+                            param_name in provided_values and 
+                            value != provided_values[param_name]
+                        )
+                        
+                        suggestions.append(ParameterSuggestion(
+                            parameter_name=param_name,
+                            suggested_value=value,
+                            reasoning="\n".join(reasoning_lines) if reasoning_lines else "No reasoning provided",
+                            differs_from_default=differs_from_default,
+                            differs_from_provided=differs_from_provided
+                        ))
+            
+            if summary:
+                suggestions.append(ParameterSuggestion(
+                    parameter_name="summary",
+                    suggested_value=summary,
+                    reasoning="Summary of the suggested configuration",
+                    differs_from_default=False,
+                    differs_from_provided=False
+                ))
+            
+            print(f"\nTotal suggestions parsed: {len(suggestions)}")
+            for s in suggestions:
+                print(f"- {s.parameter_name}: {s.suggested_value}")
+                if s.differs_from_default:
+                    print(f"  (differs from default: {s.differs_from_default})")
+                if s.differs_from_provided:
+                    print(f"  (differs from provided: {s.differs_from_provided})")
+            
+            return suggestions
+            
+        except Exception as e:
+            print(f"ERROR: Failed to parse AI response: {str(e)}")
+            print(f"Raw response: {json.dumps(ai_response, indent=2)}")
+            return [] 

--- a/services/libert_ai_service.py
+++ b/services/libert_ai_service.py
@@ -1,4 +1,3 @@
-import os
 import json
 import logging
 import aiohttp

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,3 @@
+"""
+Tests package initialization.
+""" 

--- a/tests/test_libert_ai_service.py
+++ b/tests/test_libert_ai_service.py
@@ -1,0 +1,164 @@
+import pytest
+from services.libert_ai_service import LibertAIService
+from routers.strategies_models import (
+    ParameterSuggestion,
+    discover_strategies,
+)
+from typing import Any
+from dataclasses import dataclass
+
+@pytest.fixture
+def libert_ai_service():
+    service = LibertAIService()
+    return service
+
+@pytest.fixture
+def strategy_configs():
+    """Load all available strategies"""
+    return discover_strategies()
+
+@pytest.fixture
+def bollinger_strategy(strategy_configs):
+    """Get the Bollinger strategy configuration"""
+    return strategy_configs["bollinger_v1"]
+
+@pytest.mark.asyncio
+async def test_initialize_system_context(libert_ai_service):
+    """Test system context initialization"""
+    await libert_ai_service._initialize_system_context()
+
+@pytest.mark.asyncio
+async def test_initialize_strategy_context(libert_ai_service, bollinger_strategy):
+    """Test strategy context initialization"""
+    with open(f"bots/{bollinger_strategy.mapping.module_path.split('bots.')[-1].replace('.', '/')}.py", "r") as f:
+        strategy_code = f.read()
+    
+    await libert_ai_service._initialize_strategy_context(
+        strategy_mapping=bollinger_strategy.mapping,
+        strategy_config=bollinger_strategy.parameters,
+        strategy_code=strategy_code,
+        slot_id=0
+    )
+
+@pytest.mark.asyncio
+async def test_get_parameter_suggestions(libert_ai_service, bollinger_strategy):
+    """Test parameter suggestion generation"""
+    
+    libert_ai_service.strategy_slot_map["bollinger_v1"] = 0
+
+    suggestions = await libert_ai_service.get_parameter_suggestions(
+        strategy_id="bollinger_v1",
+        strategy_config=bollinger_strategy.parameters,
+        provided_params={"bb_std": 2.0}
+    )
+    
+    # Verify suggestions are part of the bollinger_strategy.parameters
+    for suggestion in suggestions:
+        assert suggestion.parameter_name in bollinger_strategy.parameters or suggestion.parameter_name == "summary"
+
+@pytest.mark.asyncio
+async def test_parse_ai_response(libert_ai_service):
+    """Test AI response parsing"""
+    ai_response = {
+        "choices": [{
+            "message": {
+                "content": """
+PARAMETER: bb_length
+VALUE: 100
+REASONING: Standard length for Bollinger Bands calculation provides reliable signals while filtering out noise.
+
+PARAMETER: bb_long_threshold
+VALUE: 0.2
+REASONING: Enter long positions when price is 20% below the middle band, indicating oversold conditions.
+
+SUMMARY: These parameters are optimized for mean reversion trading using Bollinger Bands.
+"""
+            }
+        }]
+    }
+    
+    # Mock strategy config with proper parameter objects
+    @dataclass
+    class MockParameter:
+        name: str
+        default: Any
+        required: bool = True
+        type: str = "float"
+        
+    strategy_config = {
+        "bb_length": MockParameter(
+            name="BB Length",
+            default=20,
+            type="int"
+        ),
+        "bb_long_threshold": MockParameter(
+            name="BB Long Threshold",
+            default=0.1,
+            type="float"
+        )
+    }
+    
+    provided_params = {
+        "bb_length": 20
+    }
+    
+    suggestions = libert_ai_service._parse_ai_response(
+        ai_response,
+        strategy_config=strategy_config,
+        provided_params=provided_params
+    )
+    
+    assert len(suggestions) == 3  # 2 parameters + summary
+    assert all(isinstance(s, ParameterSuggestion) for s in suggestions)
+    assert suggestions[0].parameter_name == "bb_length"
+    assert suggestions[0].suggested_value == "100"
+    assert suggestions[0].differs_from_default is True  # 100 vs default 20
+    assert suggestions[0].differs_from_provided is True  # 100 vs provided 20
+    assert suggestions[1].parameter_name == "bb_long_threshold"
+    assert suggestions[1].suggested_value == "0.2"
+    assert suggestions[1].differs_from_default is True  # 0.2 vs default 0.1
+    assert suggestions[1].differs_from_provided is False  # Not provided
+    assert suggestions[2].parameter_name == "summary"
+    assert suggestions[2].suggested_value == "These parameters are optimized for mean reversion trading using Bollinger Bands."
+
+@pytest.mark.asyncio
+async def test_parse_ai_response_handles_invalid_format(libert_ai_service):
+    """Test handling of invalid AI response format"""
+    invalid_response = {
+        "choices": [{
+            "message": {
+                "content": "Invalid format response"
+            }
+        }]
+    }
+    
+    # Mock empty config with proper parameter objects
+    strategy_config = {}
+    provided_params = {}
+    
+    suggestions = libert_ai_service._parse_ai_response(
+        invalid_response,
+        strategy_config=strategy_config,
+        provided_params=provided_params
+    )
+    assert suggestions == []
+
+@pytest.mark.asyncio
+async def test_get_specific_parameter_suggestions(libert_ai_service, bollinger_strategy):
+    """Test getting suggestions for specific parameters"""
+    
+    libert_ai_service.strategy_slot_map["bollinger_v1"] = 0
+
+    # Request suggestions for specific parameters
+    requested_params = ["bb_length", "bb_long_threshold"]
+    suggestions = await libert_ai_service.get_parameter_suggestions(
+        strategy_id="bollinger_v1",
+        strategy_config=bollinger_strategy.parameters,
+        provided_params={"bb_std": 2.0},
+        requested_params=requested_params
+    )
+    
+    # Verify we only got suggestions for the requested parameters (plus summary)
+    assert len(suggestions) == 3  # 2 requested parameters + summary
+    suggestion_params = {s.parameter_name for s in suggestions if s.parameter_name != "summary"}
+    assert suggestion_params == set(requested_params) 

--- a/tests/test_strategies.py
+++ b/tests/test_strategies.py
@@ -1,0 +1,224 @@
+import pytest
+from unittest.mock import Mock, patch, MagicMock
+from decimal import Decimal
+from typing import Dict, Any
+from pydantic import BaseModel, Field
+from hummingbot.strategy_v2.controllers import ControllerConfigBase
+
+from routers.strategies_models import (
+    StrategyType,
+    StrategyMapping,
+    StrategyParameter,
+    StrategyConfig,
+    discover_strategies,
+    generate_strategy_mapping,
+    convert_to_strategy_parameter,
+    infer_strategy_type
+)
+
+# Mock strategy config class for testing
+class MockStrategyConfig(ControllerConfigBase):
+    """Test strategy for unit testing"""
+    controller_name = "test_strategy_v1"
+    
+    stop_loss: Decimal = Field(
+        default=Decimal("0.03"),
+        description="Stop loss percentage",
+        ge=Decimal("0"),
+        le=Decimal("1")
+    )
+    take_profit: Decimal = Field(
+        default=Decimal("0.02"),
+        description="Take profit percentage",
+        ge=Decimal("0"),
+        le=Decimal("1")
+    )
+    time_limit: int = Field(
+        default=2700,
+        description="Time limit in seconds",
+        gt=0
+    )
+    leverage: int = Field(
+        default=20,
+        description="Leverage multiplier",
+        gt=0
+    )
+    trading_pair: str = Field(
+        default="BTC-USDT",
+        description="Trading pair to use"
+    )
+
+# Test data
+MOCK_MODULE_PATH = "bots.controllers.directional_trading.test_strategy_v1"
+
+@pytest.fixture
+def mock_strategy_config():
+    return MockStrategyConfig
+
+@pytest.fixture(autouse=True)
+def mock_importlib():
+    with patch("importlib.import_module") as mock:
+        mock.return_value = MagicMock(
+            __name__="test_module",
+            MockStrategyConfig=MockStrategyConfig
+        )
+        yield mock
+
+@pytest.fixture(autouse=True)
+def mock_os_walk():
+    with patch("os.walk") as mock:
+        mock.return_value = [
+            ("bots/controllers/directional_trading", [], ["test_strategy_v1.py"]),
+        ]
+        yield mock
+
+@pytest.fixture(autouse=True)
+def mock_discover_strategies():
+    """Mock discover_strategies to return our test data"""
+    with patch("routers.strategies_models.discover_strategies", autospec=True) as mock:
+        mock.return_value = {
+            "test_strategy_v1": StrategyConfig(
+                mapping=StrategyMapping(
+                    id="test_strategy_v1",
+                    config_class="MockStrategyConfig",
+                    module_path=MOCK_MODULE_PATH,
+                    strategy_type=StrategyType.DIRECTIONAL_TRADING,
+                    display_name="Test Strategy V1",
+                    description="Test strategy for unit testing"
+                ),
+                parameters={
+                    "stop_loss": StrategyParameter(
+                        name="Stop Loss",
+                        group="Risk Management",
+                        type="Decimal",
+                        prompt="Enter stop loss value",
+                        default=Decimal("0.03"),
+                        required=True,
+                        min_value=Decimal("0"),
+                        max_value=Decimal("1")
+                    ),
+                    "take_profit": StrategyParameter(
+                        name="Take Profit",
+                        group="Risk Management",
+                        type="Decimal",
+                        prompt="Enter take profit value",
+                        default=Decimal("0.02"),
+                        required=True,
+                        min_value=Decimal("0"),
+                        max_value=Decimal("1")
+                    ),
+                    "time_limit": StrategyParameter(
+                        name="Time Limit",
+                        group="General Settings",
+                        type="int",
+                        prompt="Enter time limit in seconds",
+                        default=2700,
+                        required=True,
+                        min_value=0
+                    ),
+                    "leverage": StrategyParameter(
+                        name="Leverage",
+                        group="Risk Management",
+                        type="int",
+                        prompt="Enter leverage multiplier",
+                        default=20,
+                        required=True,
+                        min_value=1,
+                        is_advanced=True
+                    ),
+                    "trading_pair": StrategyParameter(
+                        name="Trading Pair",
+                        group="General Settings",
+                        type="str",
+                        prompt="Enter trading pair",
+                        default="BTC-USDT",
+                        required=True,
+                        is_trading_pair=True
+                    )
+                }
+            )
+        }
+        yield mock
+
+def test_infer_strategy_type():
+    """Test strategy type inference from module path"""
+    assert infer_strategy_type("bots.controllers.directional_trading.test", None) == StrategyType.DIRECTIONAL_TRADING
+    assert infer_strategy_type("bots.controllers.market_making.test", None) == StrategyType.MARKET_MAKING
+    assert infer_strategy_type("bots.controllers.generic.test", None) == StrategyType.GENERIC
+
+def test_generate_strategy_mapping():
+    """Test strategy mapping generation"""
+    mapping = generate_strategy_mapping(MOCK_MODULE_PATH, MockStrategyConfig)
+    
+    assert mapping.id == "test_strategy_v1"
+    assert mapping.config_class == "MockStrategyConfig"
+    assert mapping.module_path == MOCK_MODULE_PATH
+    assert mapping.strategy_type == StrategyType.DIRECTIONAL_TRADING
+    assert mapping.display_name == "Test Strategy V1"
+    assert "Test strategy for unit testing" in mapping.description
+
+def test_convert_to_strategy_parameter():
+    """Test parameter conversion from config field"""
+    # Get a field from the mock config
+    field = MockStrategyConfig.__fields__["stop_loss"]
+    param = convert_to_strategy_parameter("stop_loss", field)
+    
+    assert param.name == "Stop Loss"
+    assert param.group == "Risk Management"
+    assert param.type == "ConstrainedDecimalValue"  # We want the base type, not the constrained type
+    assert param.default == Decimal("0.03")
+    assert param.required is True
+    assert param.min_value == Decimal("0")
+    assert param.max_value == Decimal("1")
+    assert param.display_type == "slider"
+
+@pytest.mark.asyncio
+async def test_discover_strategies():
+    """Test strategy auto-discovery"""
+    strategies = discover_strategies()
+    
+    assert len(strategies) == 9
+    assert "bollinger_v1" in strategies
+    
+    strategy = strategies["bollinger_v1"]
+    assert isinstance(strategy, StrategyConfig)
+    assert strategy.mapping.id == "bollinger_v1"
+    
+    # Check some parameters
+    assert "stop_loss" in strategy.parameters
+    assert "take_profit" in strategy.parameters
+    assert strategy.parameters["leverage"].is_advanced is True
+    assert strategy.parameters["trading_pair"].is_trading_pair is True
+
+
+def test_parameter_validation():
+    """Test parameter validation in strategy config"""
+    # Test required parameters
+    with pytest.raises(ValueError):
+        MockStrategyConfig(
+            stop_loss=None,  # Required parameter missing
+            take_profit=Decimal("0.02"),
+            time_limit=2700,
+            leverage=20,
+            trading_pair="BTC-USDT"
+        )
+    
+    # Test parameter constraints
+    with pytest.raises(ValueError):
+        MockStrategyConfig(
+            stop_loss=Decimal("-0.03"),  # Negative value not allowed
+            take_profit=Decimal("0.02"),
+            time_limit=2700,
+            leverage=20,
+            trading_pair="BTC-USDT"
+        )
+
+def test_strategy_type_enum():
+    """Test StrategyType enum values"""
+    assert StrategyType.DIRECTIONAL_TRADING == "directional_trading"
+    assert StrategyType.MARKET_MAKING == "market_making"
+    assert StrategyType.GENERIC == "generic"
+    
+    # Test that invalid types are not allowed
+    with pytest.raises(ValueError):
+        StrategyType("invalid_type") 

--- a/tests/test_strategies.py
+++ b/tests/test_strategies.py
@@ -88,7 +88,9 @@ def mock_discover_strategies():
                 ),
                 parameters={
                     "stop_loss": StrategyParameter(
-                        name="Stop Loss",
+                        name="stop_loss",
+                        pretty_name="Stop Loss",
+                        description="Stop loss percentage",
                         group="Risk Management",
                         type="Decimal",
                         prompt="Enter stop loss value",
@@ -98,7 +100,9 @@ def mock_discover_strategies():
                         max_value=Decimal("1")
                     ),
                     "take_profit": StrategyParameter(
-                        name="Take Profit",
+                        name="take_profit",
+                        pretty_name="Take Profit",
+                        description="Take profit percentage",
                         group="Risk Management",
                         type="Decimal",
                         prompt="Enter take profit value",
@@ -108,7 +112,9 @@ def mock_discover_strategies():
                         max_value=Decimal("1")
                     ),
                     "time_limit": StrategyParameter(
-                        name="Time Limit",
+                        name="time_limit",
+                        pretty_name="Time Limit",
+                        description="Time limit in seconds",
                         group="General Settings",
                         type="int",
                         prompt="Enter time limit in seconds",
@@ -117,7 +123,9 @@ def mock_discover_strategies():
                         min_value=0
                     ),
                     "leverage": StrategyParameter(
-                        name="Leverage",
+                        name="leverage",
+                        pretty_name="Leverage",
+                        description="Leverage multiplier",
                         group="Risk Management",
                         type="int",
                         prompt="Enter leverage multiplier",
@@ -127,7 +135,9 @@ def mock_discover_strategies():
                         is_advanced=True
                     ),
                     "trading_pair": StrategyParameter(
-                        name="Trading Pair",
+                        name="trading_pair",
+                        pretty_name="Trading Pair",
+                        description="Trading pair to use",
                         group="General Settings",
                         type="str",
                         prompt="Enter trading pair",
@@ -163,7 +173,7 @@ def test_convert_to_strategy_parameter():
     field = MockStrategyConfig.__fields__["stop_loss"]
     param = convert_to_strategy_parameter("stop_loss", field)
     
-    assert param.name == "Stop Loss"
+    assert param.pretty_name == "Stop Loss"
     assert param.group == "Risk Management"
     assert param.type == "ConstrainedDecimalValue"  # We want the base type, not the constrained type
     assert param.default == Decimal("0.03")


### PR DESCRIPTION
## Overview
This PR introduces a new endpoint that allows users to get AI-powered suggestions for strategy parameters. The system can either suggest values for missing required parameters or provide optimized values for specific requested parameters.

## Key Changes

### New Endpoint
- Added `/strategies/suggest-parameters` POST endpoint
- Supports both automatic suggestion of missing parameters and specific parameter requests
- Returns suggestions with explanations and a summary of the configuration

### Models
- Added new request/response models for parameter suggestions
- Enhanced `ParameterSuggestionRequest` to support optional parameter selection
- Added comparison flags to show differences from default and provided values

### LibertAI Integration
- Implemented AI-powered parameter analysis
- Added system context for trading strategy expertise
- Supports strategy-specific context initialization
- Handles type conversion based on parameter definitions

### Testing
Added comprehensive test suite covering:
- Parameter suggestion generation
- AI response parsing
- Type conversion handling
- Error cases
- Specific parameter requests